### PR TITLE
Left/Right FullMapping - multiplication free

### DIFF
--- a/examples/DelayMatheiu.jl
+++ b/examples/DelayMatheiu.jl
@@ -13,22 +13,27 @@ T=2π #Principle period of the system (sin(t)=sin(t+P))
 mathieu_lddep=createMathieuProblem(3.,2.,-0.15,0.1,T=T); # LDDE problem for Hayes equation
 method=SemiDiscretization(1,0.01) # 3rd order semi discretization with Δt=0.1
 # if P = τmax, then n_steps is automatically calculated
-mapping=DiscreteMapping_1step(mathieu_lddep,method,τmax,
+mapping=DiscreteMapping_LR(mathieu_lddep,method,τmax,
     n_steps=Int((T+100eps(T))÷method.Δt),calculate_additive=true); #The discrete mapping of the system
 
 @show spectralRadiusOfMapping(mapping); # spectral radius ρ of the mapping matrix (ρ>1 unstable, ρ<1 stable)
 fp=fixPointOfMapping(mapping); # stationary solution of the hayes equation (equilibrium position)
 
 
-plot(0.0:method.Δt:P,fp[1:2:end],
-    xlabel=L"-s",title=L"t \in [nP,(n+1)P],\quad n \to \infty",guidefontsize=14,linewidth=3,
-    label=L"x(t-s)",legendfontsize=11,tickfont = font(10))
+using Plots
+gr();
+using LaTeXStrings
 
-plot!(0.0:method.Δt:P,fp[2:2:end],
-    xlabel=L"-s",linewidth=3,
-    label=L"\dot{x}(t-s)")
+plot(0.0:method.Δt:T,fp[1:2:end],
+    xlabel="-s")
+#    ,title="t \in [nP,(n+1)P],\quad n \to \infty",guidefontsize=14,linewidth=3,label=L"x(t-s)",legendfontsize=11,tickfont = font(10))
 
-plot!(0.0:method.Δt:P,sin.(2*(0.0:method.Δt:P)),linewidth=3,label=L"\sin(2t)")
+plot!(0.0:method.Δt:T,fp[2:2:end],
+    xlabel="-s")
+    #,linewidth=3,    label="\dot{x}(t-s)")
+
+plot!(0.0:method.Δt:T,sin.(2*(0.0:method.Δt:T)))
+#,linewidth=3,label="\sin(2t)")
 
 
 
@@ -38,9 +43,6 @@ plot!(0.0:method.Δt:P,sin.(2*(0.0:method.Δt:P)),linewidth=3,label=L"\sin(2t)")
 
 using MDBM
 
-using Plots
-gr();
-using LaTeXStrings
 
 a1=0.1;
 ε=1;
@@ -48,7 +50,7 @@ a1=0.1;
 T=1π;
 method=SemiDiscretization(2,T/40);
 
-foo(δ,b0) = log(spectralRadiusOfMapping(DiscreteMapping_1step(createMathieuProblem(δ,ε,b0,a1,T=T),method,τmax,
+foo(δ,b0) = log(spectralRadiusOfMapping(DiscreteMapping_LR(createMathieuProblem(δ,ε,b0,a1,T=T),method,τmax,
     n_steps=Int((T+100eps(T))÷method.Δt)))); # No additive term calculated
 
 axis=[Axis(-1:0.2:5.,:δ),

--- a/examples/HayesEquation.jl
+++ b/examples/HayesEquation.jl
@@ -2,7 +2,7 @@ using SemiDiscretizationMethod
 
 function createHayesProblem(a,b)
     AMx =  ProportionalMX(a*ones(1,1));
-    τ1=1. 
+    τ1=1.
     BMx1 = DelayMX(τ1,b*ones(1,1));
     cVec = Additive(ones(1))
     LDDEProblem(AMx,[BMx1],cVec)
@@ -11,14 +11,10 @@ end
 hayes_lddep=createHayesProblem(-1.,-1.); # LDDE problem for Hayes equation
 method=SemiDiscretization(1,0.1) # 3rd order semi discretization with Δt=0.1
 τmax=1. # the largest τ of the system
-mapping=DiscreteMapping_1step(hayes_lddep,method,τmax,n_steps=1,calculate_additive=true); #The discrete mapping of the system
+mapping=DiscreteMapping_LR(hayes_lddep,method,τmax,n_steps=1,calculate_additive=true); #The discrete mapping of the system
 
 @show spectralRadiusOfMapping(mapping); # spectral radius ρ of the mapping matrix (ρ>1 unstable, ρ<1 stable)
 @show fixPointOfMapping(mapping); # stationary solution of the hayes equation (equilibrium position)
-
-
-
-
 
 
 
@@ -32,7 +28,7 @@ using LaTeXStrings
 method=SemiDiscretization(4,0.1);
 τmax=1.
 
-foo(a,b) = log(spectralRadiusOfMapping(DiscreteMapping_1step(createHayesProblem(a,b),method,τmax,
+foo(a,b) = log(spectralRadiusOfMapping(DiscreteMapping_LR(createHayesProblem(a,b),method,τmax,
     n_steps=1))); # No additive term calculated
 
 axis=[Axis(-15.0:15.,:a),

--- a/examples/TurningSSV.jl
+++ b/examples/TurningSSV.jl
@@ -1,0 +1,60 @@
+using SemiDiscretizationMethod
+
+using Plots
+
+#--------------------Problem definitnion------------------------
+# computing the stablility of the turning process in case of SipindeSpeedVariation (in dimensionless form)
+# ζ damping of the oscillator (woth normalized natural frequency = 1)
+# kw cuttin gcoefficients
+# Ω spindle speed
+# ASSV amplitude of the delay (spindle speed) relative SipindeSpeedVariation (ASSV<<1 typically)
+# T timeperiod of the spindle speed variation
+
+function createTurningSSVProblem(kw,ζ,Ω,ASSV,T)
+    AMx =  ProportionalMX(t->@SMatrix [0. 1.; -1-kw -ζ]);
+    τ1=t -> 2π/Ω *(1+ ASSV*sin(t/T*2π)) # if function is needed, the use τ1 = t->foo(t)
+    BMx1 = DelayMX(τ1,t->@SMatrix [0. 0.; kw 0.]);
+    cVec = Additive(t->@SVector [0.,cos(t*2π)])#τ1(t)*kw
+    LDDEProblem(AMx,[BMx1],cVec)
+end;
+
+kw=0.2
+ζ=0.1
+Ω=0.3
+ASSV=0.1
+NT=10 
+T=2π / Ω * NT  #spindle speed variation in integer number of revolution (NT)
+
+τmax=2π/Ω *(1+ ASSV) # the largest τ of the system
+
+turningSSV_lddep=createTurningSSVProblem(kw,ζ,Ω,ASSV,T); # LDDE problem for Turning SSV problem
+method=SemiDiscretization(1,0.05) # 3rd order semi discretization with Δt=0.05
+### -------- Try to increase the resolutionby decreasing Δt
+
+
+#<<<<<<<<<<<<<<<<<<<<<<Stability calculation in one point>>>>>>>>>>>>>>>>>>>>>>>
+
+#--------------------------------------------------------------------------------
+#-----------------traditional mapping of SemiDiscretization----------------------
+#-----------------------faster computation if T>>τmax----------------------------
+#--------------------------------------------------------------------------------
+
+mapping=DiscreteMapping_1step(turningSSV_lddep,method,τmax,
+    n_steps=Int((T+100eps(T))÷method.Δt),calculate_additive=true); #The discrete mapping of the system
+
+@time spectralRadiusOfMapping(mapping); # spectral radius ρ of the mapping matrix (ρ>1 unstable, ρ<1 stable)
+@time fixPointOfMapping(mapping); # stationary solution of the system (equilibrium position)
+
+
+
+#----------------------------------------------------------------------------------------------
+#--------------------#updated Left\Right mapping matrices of SemiDiscretization----------------
+#----------------------- Order of magnitude faster computation if T<=τmax----------------------
+#----------------------------------------------------------------------------------------------
+mappingLR=DiscreteMapping_LR(turningSSV_lddep,method,τmax,
+    n_steps=Int((T+100eps(T))÷method.Δt),calculate_additive=true); #The discrete mapping of the system
+
+@time spectralRadiusOfMapping(mappingLR); # spectral radius ρ of the mapping matrix (ρ>1 unstable, ρ<1 stable)
+@time fixPointOfMapping(mappingLR); # stationary solution of the system (equilibrium position)
+
+

--- a/src/SemiDiscretizationMethod.jl
+++ b/src/SemiDiscretizationMethod.jl
@@ -16,12 +16,17 @@ include("functions_utility.jl")
 include("functions_discretization.jl")
 include("functions_method.jl")
 
+include("functions_LRmapping.jl")
+
+
 export SemiDiscretization, NumericSD, 
 ProportionalMX,
 Delay,DelayMX,
 Additive,
 LDDEProblem,
 DiscreteMapping, DiscreteMapping_1step,
-fixPointOfMapping, spectralRadiusOfMapping
+fixPointOfMapping, spectralRadiusOfMapping,
+DiscreteMapping_LR
+
 
 end # module

--- a/src/functions_LRmapping.jl
+++ b/src/functions_LRmapping.jl
@@ -1,0 +1,212 @@
+#spectralRadiusOfMappingFast2,# TODO: deprecated
+#PhiLeft,PhiRight,PhiSteps# TODO: deprecated
+
+#fixPointOfMappingLR, spectralRadiusOfMappingLR,  #TODO: renamed to ("LR" is removed)
+
+
+
+struct DiscreteMapping_LR{tT,mxT,vT}
+    ts::Vector{tT}
+    LmappingMX::mxT
+    RmappingMX::mxT
+    mappingVs::Vector{vT}
+end
+
+
+###############################################################################
+############################## Discrete Mapping ###############################
+###############################################################################
+function DiscreteMapping_LR(LDDEP::AbstractLDDEProblem, method::DiscretizationMethod, DiscretizationLength::Real; n_steps::Int64=nStepOfLength(DiscretizationLength, method.Δt), calculate_additive::Bool=false)
+    result = calculateResults(LDDEP, method, DiscretizationLength,n_steps = n_steps, calculate_additive = calculate_additive);
+    DiscreteMapping_LR(DiscreteMappingSteps_LR(result)...)
+end
+
+
+
+function DiscreteMappingSteps_LR(rst::AbstractResult{d}) where d
+    NT=size(rst.subMXs[1])[1];
+    Nτ=rst.n ÷ d;
+    Nmaximal=max(Nτ,NT);
+
+    ΦL=spdiagm( 0 => ones(d * Nmaximal));
+    if Nτ>NT
+        ΦR=spdiagm( -d * (NT) => ones(d * (Nτ-NT)));
+    else
+        ΦR=spzeros(d * Nmaximal, d * Nmaximal );
+    end
+
+   for smx_t in rst.subMXs
+        for (it,smx) in enumerate(smx_t) 
+           # pos=(it-1)*d
+           # addSubmatrixToL!(ΦL,smx,pos,pos,NT*d)
+           # addSubmatrixToR!(ΦR,smx,pos,pos-NT*d,Nmaximal*d)
+            addSubmatrixToL!(ΦL,smx,(it-1)*d,it*d,NT*d)
+            addSubmatrixToR!(ΦR,smx,(it-1)*d,(it-NT)*d,Nmaximal*d)
+        end
+    end
+    
+    mappingVs = [spzeros(size(ΦL,1))];
+
+    for (it,subV) in enumerate(rst.subVs) 
+       # pos=(it-1)*d
+       # mappingVs[1][(1+pos) : (d+pos)] .+= subV.V
+        mappingVs[1][(1+(it-1)*d) : (d+(it-1)*d)] .+= subV.V
+    end
+    ([rst.ts[1],rst.ts[end]],ΦL,ΦR,mappingVs)
+end
+
+function addSubmatrixToL!(Φ::AbstractArray, subMX::SubMX, it_shift1, it_shift2, nlimit)
+    for i in eachindex(subMX.ranges, subMX.MXs)
+        positionrange=LR_positionshift(subMX.ranges[i],it_shift1,it_shift2);
+        if (positionrange[2][end])<=nlimit && (positionrange[2][1])>0 
+            Φ[positionrange...] .+= -subMX.MXs[i];
+        end
+    end
+end
+
+function addSubmatrixToR!(Φ::AbstractArray, subMX::SubMX, it_shift1, it_shift2, nlimit)
+    for i in eachindex(subMX.ranges, subMX.MXs)
+        positionrange=LR_positionshift(subMX.ranges[i],it_shift1,it_shift2);
+        if (positionrange[2][1])>0 
+            Φ[positionrange...] .+= subMX.MXs[i];
+        end
+    end
+end
+
+
+function LR_positionshift(range::Tuple{UnitRange{Int64},UnitRange{Int64}},d)
+    ((range[1][1]+d):(range[1][end]+d),(range[2][1]+d):(range[2][end]+d))
+end
+
+function LR_positionshift(range::Tuple{UnitRange{Int64},UnitRange{Int64}},d1,d2)
+    ((range[1][1]+d1):(range[1][end]+d1),(range[2][1]+d2):(range[2][end]+d2))
+end
+      
+
+function spectralRadiusOfMapping(mappLR::DiscreteMapping_LR; args...)
+    return abs(eigs(mappLR.RmappingMX,mappLR.LmappingMX; args...)[1][1])
+end
+
+function fixPointOfMapping(mappLR::DiscreteMapping_LR)
+    (mappLR.LmappingMX-mappLR.RmappingMX) \ Vector(mappLR.mappingVs[1])
+end
+
+
+
+
+
+############ TODO: deprecated
+
+
+
+abstract type PhiLR{T} end
+
+
+
+
+struct PhiSteps{Ti}
+    dm::DiscreteMapping
+    NT::Ti
+    Nτ::Ti
+    BS::Ti#BlockSize
+end
+
+function PhiSteps(dm::DiscreteMapping,BS::Integer)
+    NT=size(dm.mappingMXs)[1];
+    Nτ=size(dm.mappingMXs[1])[2] ÷ BS;
+    PhiSteps(dm,NT,Nτ,BS);
+ end
+ Base.size(Φs::PhiSteps)  = (Φs.NT*Φs.BS,(Φs.Nτ+Φs.NT)*Φs.BS,);
+ Base.size(Φs::PhiSteps, indDim::Integer) = indDim==1 ? Φs.NT*Φs.BS : (Φs.Nτ+Φs.NT)*Φs.BS;
+
+ function Base.getindex(Φs::PhiSteps, idx1,idx2) 
+    idxNT,subidx1=divrem(idx1-1, Φs.BS);
+    idxNT += 1;
+    subidx1 += 1;
+    subidx2 = idx2 - (idxNT-1) * Φs.BS;
+    if subidx2<=Φs.BS
+        return subidx1==subidx2 ? 1.0 : 0.0
+    elseif (subidx2-2)>Φs.Nτ * Φs.BS
+        return 0.0
+    else
+        return -Φs.dm.mappingMXs[idxNT][subidx1,subidx2-Φs.BS]
+    end
+end
+
+
+struct PhiLeft <:AbstractMatrix{Float64}
+    properties
+    Ps::PhiSteps
+end
+
+function Base.getindex(ΦL::PhiLeft, idx1,idx2)
+    if idx1 <= (ΦL.Ps.BS * ΦL.Ps.NT) && idx2 <= (ΦL.Ps.BS * ΦL.Ps.NT)
+        return ΦL.Ps[idx1,idx2]
+    elseif idx1==idx2
+        return 1.0
+    else
+        return 0.0
+    end
+    return 0.0
+end
+Base.size(ΦL::PhiLeft)  = (maximum([ΦL.Ps.Nτ,ΦL.Ps.NT])*ΦL.Ps.BS,maximum([ΦL.Ps.Nτ,ΦL.Ps.NT])*ΦL.Ps.BS,);
+Base.size(ΦL::PhiLeft, Icucc::Integer) = maximum([ΦL.Ps.Nτ,ΦL.Ps.NT])*ΦL.Ps.BS;
+Base.zero(ΦL::PhiLeft)= zeros(typeof(ΦL.Ps.dm.mappingMXs[1][1]),size(ΦL)...);
+
+
+struct PhiRight <:AbstractMatrix{Float64}
+    Ps::PhiSteps
+end
+
+function Base.getindex(ΦR::PhiRight, idx1,idx2)
+    if idx1 <= (ΦR.Ps.BS * ΦR.Ps.NT)
+        return -ΦR.Ps[idx1,idx2+ΦR.Ps.BS * ΦR.Ps.NT]
+    elseif (idx1-ΦR.Ps.BS * ΦR.Ps.NT)==idx2
+        return 1.0
+    else
+        return 0.0
+    end
+    return 0.0
+end
+Base.size(ΦR::PhiRight)  = (maximum([ΦR.Ps.Nτ,ΦR.Ps.NT])*ΦR.Ps.BS,maximum([ΦR.Ps.Nτ,ΦR.Ps.NT])*ΦR.Ps.BS,);
+Base.size(ΦR::PhiRight, Icucc::Integer) = maximum([ΦR.Ps.Nτ,ΦR.Ps.NT])*ΦR.Ps.BS;
+Base.zero(ΦR::PhiRight)= zeros(typeof(ΦR.Ps.dm.mappingMXs[1][1]),size(ΦR)...);
+
+
+
+function spectralRadiusOfMappingFast2(dm::DiscreteMapping, BlockSize::Integer; args...)
+  
+    #@show  BlockSize=size(mathieu_lddep.A(0))[2];
+    NT=size(dm.mappingMXs)[1];
+    Nτ=size(dm.mappingMXs[1])[2] ÷ BlockSize;
+    #if 0>1
+    #    Φsteps = spzeros(BlockSize * NT, BlockSize * (NT + Nτ ));
+    #    for k in 1:NT
+    #    Φsteps[(1:BlockSize) .+ (k-1) * BlockSize,(1:BlockSize) .+ (k-1) * BlockSize] .= diagm(ones(BlockSize));
+    #    Φsteps[(1:BlockSize) .+ (k-1) * BlockSize,(1:(Nτ * BlockSize)) .+ (k) * BlockSize] .= -dm.mappingMXs[k][1:BlockSize,:];
+    #    end
+    #else
+        Φsteps=spdiagm(BlockSize * NT, BlockSize * (NT + Nτ ), 0 => ones(BlockSize * NT))
+        #dropzeros!.(Φsteps)
+        for k in 1:NT
+            Φsteps[(1:BlockSize) .+ (k-1) * BlockSize,(1:(Nτ * BlockSize)) .+ (k) * BlockSize] .= -dm.mappingMXs[k][1:BlockSize,:];
+            # (I,J,V)=findnz(dm.mappingMXs[k][1:BlockSize,:])
+            # Φsteps += sparse(I, J .+ k*BlockSize, V,BlockSize * NT, BlockSize * (NT + Nτ ));
+        end
+        dropzeros!(Φsteps)
+    #end
+
+    Nmaximal=maximum([Nτ,NT]);
+    ΦL=spdiagm( 0 => ones(BlockSize * Nmaximal));
+    ΦL[1:BlockSize * NT, 1:BlockSize * NT ] .= Φsteps[1:BlockSize * NT, 1:BlockSize * NT ];
+    dropzeros!(ΦL)
+    ΦR=spzeros(BlockSize * Nmaximal, BlockSize * Nmaximal );
+    ΦR[1:BlockSize * NT,1:BlockSize * Nτ]= -Φsteps[1:BlockSize * NT,BlockSize * NT + 1 : end];
+    if Nτ>NT
+        ΦR[BlockSize * NT+1:end, 1:BlockSize * (Nτ-NT)] .= diagm(ones(BlockSize * (Nτ-NT)));
+    end  
+    #return 0.0
+    #return abs(eigs(ΦR,ΦL; args...)[1][1]),ΦR,ΦL,Φsteps
+    return ΦR,ΦL#,Φsteps
+end
+


### PR DESCRIPTION
There is no need to build the FullStepp matix, if each steps is represented and collected in a Left and Right Matrix.
It speeds up the calculation for spectralradius and for the fixed point.
Note, is some case, if T>>τmax, the original version can be faster, especially if not all the value of the delayed statespace is needed.
